### PR TITLE
Cleanup failing GH workflows

### DIFF
--- a/.github/workflows/call-run-tests.yml
+++ b/.github/workflows/call-run-tests.yml
@@ -21,7 +21,7 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Run Playwright tests
-        run: npm run gh:test
+        run: npm run test
 
       - uses: actions/upload-artifact@v3
         if: always()


### PR DESCRIPTION
### Changes:

- update run test script GH workflow to remove saving traceviewer logs
   - `--trace on` enables traceviewer logs which contains the recorded Playwright traces after the script has ran
   - read more about traceviewer [here](https://playwright.dev/docs/trace-viewer)


Note: This PR has the refactor-search-test changes to test if the pipeline works
