### PR TITLE
Add music page tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,6 +22,8 @@ const reportName = () => `${process.env.CATEGORY}/${formattedDateTime()}`;
  */
 export default defineConfig({
   workers: 1,
+  timeout: 240000,
+  globalTimeout: 360000,
   testDir: './tests',
   reporter: [
     [

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -76,4 +76,9 @@ export const test = base.extend<PageFixtures>({
   },
 });
 
+test.beforeEach(async ({}, testInfo) => {
+  // Extend timeout for all tests running this hook by 180 seconds.
+  testInfo.setTimeout(testInfo.timeout + 180000);
+});
+
 export { expect } from '@playwright/test';

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -76,9 +76,9 @@ export const test = base.extend<PageFixtures>({
   },
 });
 
-test.beforeEach(async ({}, testInfo) => {
-  // Extend timeout for all tests running this hook by 180 seconds.
-  testInfo.setTimeout(testInfo.timeout + 180000);
+test.beforeEach(async ({ request }) => {
+  const whathost = await request.get('/services/whathost.php');
+  console.log('whathost: ', await whathost.text());
 });
 
 export { expect } from '@playwright/test';

--- a/tests/music/music.spec.ts
+++ b/tests/music/music.spec.ts
@@ -3,7 +3,6 @@ import { test } from '../fixtures';
 test('Load and Play a Grateful Dead Soundtrack', async ({ musicPage }) => {
   await musicPage.gotoMusicPage('gd73-06-10.sbd.hollister.174.sbeok.shnf');
   await musicPage.validateMusicPageElements();
-  // await musicPage.interactWithBookReader();
   await musicPage.playAndPauseMusic();
 });
 
@@ -13,7 +12,6 @@ test(`Special case: Audio item without image - with waveform`, async ({
   await musicPage.gotoMusicPage('gd77-05-08.sbd.hicks.4982.sbeok.shnf');
   await musicPage.validateMusicPageElements();
   await musicPage.validateNoImageAvailableInPhotoViewerDisplay(true);
-  // await musicPage.interactWithBookReader();
   await musicPage.validateNoWaveformDisplay(false);
 });
 

--- a/tests/music/music.spec.ts
+++ b/tests/music/music.spec.ts
@@ -1,8 +1,19 @@
 import { test } from '../fixtures';
 
-test('Play a Grateful Dead Soundtrack', async ({ musicPage }) => {
+test('Load and Play a Grateful Dead Soundtrack', async ({ musicPage }) => {
   await musicPage.gotoMusicPage('gd73-06-10.sbd.hollister.174.sbeok.shnf');
-  await musicPage.validatePageElements();
+  await musicPage.validateCommonPageElements();
   await musicPage.playAndPauseMusic();
-  await musicPage.page.close();
+});
+
+test(`Special case: Audio item without image - with waveform`, async ({ musicPage }) => {
+  await musicPage.gotoMusicPage('gd77-05-08.sbd.hicks.4982.sbeok.shnf');
+  await musicPage.validateNoImageAvailableInPhotoViewerDisplay(true);
+  await musicPage.validateNoWaveformDisplay(false);
+});
+
+test(`Special case: Load a single track - no waveform`, async ({ musicPage }) => {
+  await musicPage.gotoMusicPage('berceuse00benj');
+  await musicPage.validateNoImageAvailableInPhotoViewerDisplay(false);
+  await musicPage.validateNoWaveformDisplay(true);
 });

--- a/tests/music/music.spec.ts
+++ b/tests/music/music.spec.ts
@@ -2,18 +2,26 @@ import { test } from '../fixtures';
 
 test('Load and Play a Grateful Dead Soundtrack', async ({ musicPage }) => {
   await musicPage.gotoMusicPage('gd73-06-10.sbd.hollister.174.sbeok.shnf');
-  await musicPage.validateCommonPageElements();
+  await musicPage.validateMusicPageElements();
+  // await musicPage.interactWithBookReader();
   await musicPage.playAndPauseMusic();
 });
 
-test(`Special case: Audio item without image - with waveform`, async ({ musicPage }) => {
+test(`Special case: Audio item without image - with waveform`, async ({
+  musicPage,
+}) => {
   await musicPage.gotoMusicPage('gd77-05-08.sbd.hicks.4982.sbeok.shnf');
+  await musicPage.validateMusicPageElements();
   await musicPage.validateNoImageAvailableInPhotoViewerDisplay(true);
+  // await musicPage.interactWithBookReader();
   await musicPage.validateNoWaveformDisplay(false);
 });
 
-test(`Special case: Load a single track - no waveform`, async ({ musicPage }) => {
+test(`Special case: Load a single track - no waveform`, async ({
+  musicPage,
+}) => {
   await musicPage.gotoMusicPage('berceuse00benj');
+  await musicPage.validateMusicPageElements();
   await musicPage.validateNoImageAvailableInPhotoViewerDisplay(false);
   await musicPage.validateNoWaveformDisplay(true);
 });

--- a/tests/page-objects/music-page.ts
+++ b/tests/page-objects/music-page.ts
@@ -1,16 +1,29 @@
 import { type Page, type Locator, expect } from '@playwright/test';
 
+import { BookPage } from './book-page';
 export class MusicPage {
   readonly page: Page;
+
   readonly iauxPhotoViewer: Locator;
   readonly iauxMusicTheater: Locator;
   readonly playAv: Locator;
+  readonly seeMoreCta: Locator;
+  readonly brSlot: Locator;
+  readonly bookReaderShell: Locator;
+
+  readonly bookPage: BookPage;
 
   public constructor(page: Page) {
     this.page = page;
+
     this.iauxMusicTheater = this.page.locator('ia-music-theater');
-    this.iauxPhotoViewer = this.page.locator('#music-theater > iaux-photo-viewer');
+    this.iauxPhotoViewer = this.page.locator(
+      '#music-theater > iaux-photo-viewer',
+    );
     this.playAv = this.page.locator('play-av');
+    this.seeMoreCta = this.iauxPhotoViewer.locator('#see-more-cta');
+    this.brSlot = this.page.locator('#theatre-ia > div.row > div > ia-music-theater > div.bookreader-slot');
+    this.bookReaderShell = this.brSlot.locator('#BookReader');
   }
 
   async gotoMusicPage(uri: string) {
@@ -21,7 +34,7 @@ export class MusicPage {
     await this.page.waitForTimeout(5000);
   }
 
-  async validateCommonPageElements() {
+  async validateMusicPageElements() {
     // player controls
     const musicTheater = this.iauxMusicTheater.locator('#music-theater');
     const channelSelector = this.iauxMusicTheater.locator('channel-selector');
@@ -34,26 +47,81 @@ export class MusicPage {
 
     await expect(this.iauxPhotoViewer).toBeVisible({ timeout: 60000 });
     await expect(this.playAv).toBeVisible({ timeout: 60000 });
+
+    await expect(
+      this.playAv.locator('div.playlist > div.track-list'),
+    ).toBeVisible({ timeout: 60000 });
   }
 
-  async validateNoImageAvailableInPhotoViewerDisplay(noImage: boolean) {
-    if (noImage) {
-      expect(await this.iauxPhotoViewer.getAttribute('noimageavailable')).toBe('')
-      await expect(this.iauxPhotoViewer.locator('iamusic-noimage')).toBeVisible({timeout: 60000});
-      await expect(this.iauxMusicTheater.locator('#BookReader')).not.toBeVisible({timeout: 60000});
+  async validateNoImageAvailableInPhotoViewerDisplay(noPlaceholder: boolean) {
+    console.log('noPlaceholder: ', noPlaceholder)
+    
+    if (noPlaceholder) {
+      expect(await this.iauxPhotoViewer.getAttribute('noimageavailable')).toBe(
+        '',
+      );
+      await expect(this.iauxPhotoViewer.locator('iamusic-noimage')).toBeVisible(
+        { timeout: 60000 },
+      );
+      await expect(
+        this.iauxMusicTheater.locator('#BookReader'),
+      ).not.toBeVisible({ timeout: 60000 });
     } else {
-      expect(await this.iauxPhotoViewer.getAttribute('noimageavailable')).toBe(null);
-      await expect(this.iauxPhotoViewer.locator('#see-more-cta')).toBeVisible({timeout: 60000});
-      await expect(this.iauxMusicTheater.locator('#BookReader')).toBeVisible({timeout: 60000});
+      expect(await this.iauxPhotoViewer.getAttribute('noimageavailable')).toBe(
+        null,
+      );
+      await expect(this.seeMoreCta).toBeVisible({
+        timeout: 60000,
+      });
+      await expect(this.iauxMusicTheater.locator('#BookReader')).toBeVisible({
+        timeout: 60000,
+      });
+
+      await this.interactWithBookReader();
     }
+  }
+
+  async getBookReaderClass() {
+    return await this.bookReaderShell.getAttribute('class', { timeout: 3000 });
+  }
+
+  async interactWithBookReader() {
+    console.log('interact with bookreader')
+
+    const oneUpClass = 'BRmode1up';
+    const thumbViewModeClass = 'BRmodeThumb';
+    const fullScreenClass = 'fullscreenActive';
+    const brFooter = this.bookReaderShell.locator('.BRfooter');
+
+    await this.seeMoreCta.click({ timeout: 30000 });
+    expect(await this.iauxPhotoViewer.getAttribute('showallphotos')).toBe('');
+
+    // initial load
+    expect(await this.getBookReaderClass()).toContain(oneUpClass);
+
+    // click fullscreen
+    await brFooter.locator('.BRicon.full').click();
+    expect(await this.getBookReaderClass()).toContain(fullScreenClass);
+
+    // click thumbnail mode
+    await brFooter.locator('.BRicon.thumb').click();
+    expect(await this.getBookReaderClass()).toContain(thumbViewModeClass);
+
+    // close BookReader photoViewer
+    await this.iauxPhotoViewer.locator('#close-photo-viewer').click();
+    expect(await this.iauxPhotoViewer.getAttribute('showallphotos')).toBe(null);
   }
 
   async validateNoWaveformDisplay(noWaveform: boolean) {
     const blackWaveform = 'https://archive.org/images/black.jpg';
-    if(noWaveform) {
-      expect(await this.playAv.locator('#waveformer-wrap > img').getAttribute('src')).toBe(blackWaveform)
+    if (noWaveform) {
+      expect(
+        await this.playAv.locator('#waveformer-wrap > img').getAttribute('src'),
+      ).toBe(blackWaveform);
     } else {
-      expect(await this.playAv.locator('#waveformer-wrap > img').getAttribute('src')).not.toBe(blackWaveform)
+      expect(
+        await this.playAv.locator('#waveformer-wrap > img').getAttribute('src'),
+      ).not.toBe(blackWaveform);
     }
   }
 
@@ -69,5 +137,4 @@ export class MusicPage {
       this.page.locator('#jw6.jwplayer.jw-reset.jw-state-paused'),
     ).toBeVisible({ timeout: 60000 });
   }
-
 }

--- a/tests/page-objects/music-page.ts
+++ b/tests/page-objects/music-page.ts
@@ -86,8 +86,6 @@ export class MusicPage {
   }
 
   async interactWithBookReader() {
-    console.log('interact with bookreader')
-
     const oneUpClass = 'BRmode1up';
     const thumbViewModeClass = 'BRmodeThumb';
     const fullScreenClass = 'fullscreenActive';

--- a/tests/page-objects/music-page.ts
+++ b/tests/page-objects/music-page.ts
@@ -1,6 +1,5 @@
 import { type Page, type Locator, expect } from '@playwright/test';
 
-import { BookPage } from './book-page';
 export class MusicPage {
   readonly page: Page;
 
@@ -11,8 +10,6 @@ export class MusicPage {
   readonly brSlot: Locator;
   readonly bookReaderShell: Locator;
 
-  readonly bookPage: BookPage;
-
   public constructor(page: Page) {
     this.page = page;
 
@@ -22,14 +19,15 @@ export class MusicPage {
     );
     this.playAv = this.page.locator('play-av');
     this.seeMoreCta = this.iauxPhotoViewer.locator('#see-more-cta');
-    this.brSlot = this.page.locator('#theatre-ia > div.row > div > ia-music-theater > div.bookreader-slot');
+    this.brSlot = this.page.locator(
+      '#theatre-ia > div.row > div > ia-music-theater > div.bookreader-slot',
+    );
     this.bookReaderShell = this.brSlot.locator('#BookReader');
   }
 
   async gotoMusicPage(uri: string) {
     await this.page.goto(`/details/${uri}`, {
-      waitUntil: 'networkidle',
-      timeout: 120000,
+      waitUntil: 'networkidle'
     });
     await this.page.waitForTimeout(5000);
   }
@@ -38,51 +36,45 @@ export class MusicPage {
     // player controls
     const musicTheater = this.iauxMusicTheater.locator('#music-theater');
     const channelSelector = this.iauxMusicTheater.locator('channel-selector');
-    await expect(musicTheater).toBeVisible({ timeout: 60000 });
-    await expect(channelSelector).toBeVisible({ timeout: 60000 });
+    await expect(musicTheater).toBeVisible();
+    await expect(channelSelector).toBeVisible();
 
     const rows = channelSelector.locator('#radio').getByRole('listitem');
     expect(await rows.count()).toEqual(2);
     await expect(rows).toHaveText(['Player', 'Webamp']);
 
-    await expect(this.iauxPhotoViewer).toBeVisible({ timeout: 60000 });
-    await expect(this.playAv).toBeVisible({ timeout: 60000 });
+    await expect(this.iauxPhotoViewer).toBeVisible();
+    await expect(this.playAv).toBeVisible();
 
     await expect(
       this.playAv.locator('div.playlist > div.track-list'),
-    ).toBeVisible({ timeout: 60000 });
+    ).toBeVisible();
   }
 
   async validateNoImageAvailableInPhotoViewerDisplay(noPlaceholder: boolean) {
-    console.log('noPlaceholder: ', noPlaceholder)
-    
     if (noPlaceholder) {
       expect(await this.iauxPhotoViewer.getAttribute('noimageavailable')).toBe(
         '',
       );
-      await expect(this.iauxPhotoViewer.locator('iamusic-noimage')).toBeVisible(
-        { timeout: 60000 },
-      );
+      await expect(
+        this.iauxPhotoViewer.locator('iamusic-noimage'),
+      ).toBeVisible();
       await expect(
         this.iauxMusicTheater.locator('#BookReader'),
-      ).not.toBeVisible({ timeout: 60000 });
+      ).not.toBeVisible();
     } else {
       expect(await this.iauxPhotoViewer.getAttribute('noimageavailable')).toBe(
         null,
       );
-      await expect(this.seeMoreCta).toBeVisible({
-        timeout: 60000,
-      });
-      await expect(this.iauxMusicTheater.locator('#BookReader')).toBeVisible({
-        timeout: 60000,
-      });
+      await expect(this.seeMoreCta).toBeVisible();
+      await expect(this.iauxMusicTheater.locator('#BookReader')).toBeVisible();
 
       await this.interactWithBookReader();
     }
   }
 
   async getBookReaderClass() {
-    return await this.bookReaderShell.getAttribute('class', { timeout: 3000 });
+    return await this.bookReaderShell.getAttribute('class');
   }
 
   async interactWithBookReader() {
@@ -91,19 +83,27 @@ export class MusicPage {
     const fullScreenClass = 'fullscreenActive';
     const brFooter = this.bookReaderShell.locator('.BRfooter');
 
-    await this.seeMoreCta.click({ timeout: 30000 });
+    await this.seeMoreCta.click({ timeout: 10000 });
     expect(await this.iauxPhotoViewer.getAttribute('showallphotos')).toBe('');
 
-    // initial load
+    // default load
+    expect(await this.getBookReaderClass()).toContain(oneUpClass);
+
+    // click thumbnail mode
+    await brFooter.locator('.BRicon.thumb').click();
+    expect(await this.getBookReaderClass()).toContain(thumbViewModeClass);
+
+    // click 1up mode
+    await brFooter.locator('.BRicon.onepg').click();
     expect(await this.getBookReaderClass()).toContain(oneUpClass);
 
     // click fullscreen
     await brFooter.locator('.BRicon.full').click();
     expect(await this.getBookReaderClass()).toContain(fullScreenClass);
 
-    // click thumbnail mode
-    await brFooter.locator('.BRicon.thumb').click();
-    expect(await this.getBookReaderClass()).toContain(thumbViewModeClass);
+    // click fullscreen again
+    await brFooter.locator('.BRicon.full').click();
+    expect(await this.getBookReaderClass()).not.toContain(fullScreenClass);
 
     // close BookReader photoViewer
     await this.iauxPhotoViewer.locator('#close-photo-viewer').click();
@@ -128,11 +128,11 @@ export class MusicPage {
     await this.page.getByRole('button', { name: 'Play', exact: true }).click();
     await expect(
       this.page.locator('#jw6.jwplayer.jw-reset.jw-state-playing'),
-    ).toBeVisible({ timeout: 60000 });
+    ).toBeVisible();
     // Pause music
     await this.page.getByRole('button', { name: 'Pause' }).click();
     await expect(
       this.page.locator('#jw6.jwplayer.jw-reset.jw-state-paused'),
-    ).toBeVisible({ timeout: 60000 });
+    ).toBeVisible();
   }
 }

--- a/tests/page-objects/music-page.ts
+++ b/tests/page-objects/music-page.ts
@@ -1,23 +1,30 @@
-import { type Page, expect } from '@playwright/test';
+import { type Page, type Locator, expect } from '@playwright/test';
 
 export class MusicPage {
   readonly page: Page;
+  readonly iauxPhotoViewer: Locator;
+  readonly iauxMusicTheater: Locator;
+  readonly playAv: Locator;
 
   public constructor(page: Page) {
     this.page = page;
+    this.iauxMusicTheater = this.page.locator('ia-music-theater');
+    this.iauxPhotoViewer = this.page.locator('#music-theater > iaux-photo-viewer');
+    this.playAv = this.page.locator('play-av');
   }
 
-  async gotoMusicPage(page: string) {
-    await this.page.goto(`/details/${page}`, {
+  async gotoMusicPage(uri: string) {
+    await this.page.goto(`/details/${uri}`, {
       waitUntil: 'networkidle',
-      timeout: 60000,
+      timeout: 120000,
     });
+    await this.page.waitForTimeout(5000);
   }
 
-  async validatePageElements() {
+  async validateCommonPageElements() {
     // player controls
-    const musicTheater = this.page.locator('#music-theater');
-    const channelSelector = this.page.locator('channel-selector');
+    const musicTheater = this.iauxMusicTheater.locator('#music-theater');
+    const channelSelector = this.iauxMusicTheater.locator('channel-selector');
     await expect(musicTheater).toBeVisible({ timeout: 60000 });
     await expect(channelSelector).toBeVisible({ timeout: 60000 });
 
@@ -25,9 +32,29 @@ export class MusicPage {
     expect(await rows.count()).toEqual(2);
     await expect(rows).toHaveText(['Player', 'Webamp']);
 
-    // photo-viewer
-    const iauxPhotoViewer = this.page.locator('iaux-photo-viewer');
-    await expect(iauxPhotoViewer).toBeVisible({ timeout: 60000 });
+    await expect(this.iauxPhotoViewer).toBeVisible({ timeout: 60000 });
+    await expect(this.playAv).toBeVisible({ timeout: 60000 });
+  }
+
+  async validateNoImageAvailableInPhotoViewerDisplay(noImage: boolean) {
+    if (noImage) {
+      expect(await this.iauxPhotoViewer.getAttribute('noimageavailable')).toBe('')
+      await expect(this.iauxPhotoViewer.locator('iamusic-noimage')).toBeVisible({timeout: 60000});
+      await expect(this.iauxMusicTheater.locator('#BookReader')).not.toBeVisible({timeout: 60000});
+    } else {
+      expect(await this.iauxPhotoViewer.getAttribute('noimageavailable')).toBe(null);
+      await expect(this.iauxPhotoViewer.locator('#see-more-cta')).toBeVisible({timeout: 60000});
+      await expect(this.iauxMusicTheater.locator('#BookReader')).toBeVisible({timeout: 60000});
+    }
+  }
+
+  async validateNoWaveformDisplay(noWaveform: boolean) {
+    const blackWaveform = 'https://archive.org/images/black.jpg';
+    if(noWaveform) {
+      expect(await this.playAv.locator('#waveformer-wrap > img').getAttribute('src')).toBe(blackWaveform)
+    } else {
+      expect(await this.playAv.locator('#waveformer-wrap > img').getAttribute('src')).not.toBe(blackWaveform)
+    }
   }
 
   async playAndPauseMusic() {
@@ -42,4 +69,5 @@ export class MusicPage {
       this.page.locator('#jw6.jwplayer.jw-reset.jw-state-paused'),
     ).toBeVisible({ timeout: 60000 });
   }
+
 }


### PR DESCRIPTION
### Updates:

- Load and Play a Grateful Dead Soundtrack
  - check common page elements
- Special case: Audio item without image - with waveform
- Special case: Load a single track - no waveform