### PR TITLE
Fix and comment flaky e2e details and login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.41.2",
+        "@playwright/test": "^1.44.0",
         "@types/node": "^20.11.17",
         "browserstack-local": "^1.4.8",
         "dotenv": "^16.0.3",
@@ -156,12 +156,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.41.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.2.tgz",
-      "integrity": "sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.0.tgz",
+      "integrity": "sha512-rNX5lbNidamSUorBhB4XZ9SQTjAqfe5M+p37Z8ic0jPFBMo5iCtQz1kRWkEMg+rYOKSlVycpQmpqjSFq7LXOfg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.41.2"
+        "playwright": "1.44.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1441,12 +1442,13 @@
       "dev": true
     },
     "node_modules/playwright": {
-      "version": "1.41.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.2.tgz",
-      "integrity": "sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
+      "integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.41.2"
+        "playwright-core": "1.44.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1458,23 +1460,24 @@
         "fsevents": "2.3.2"
       }
     },
-    "node_modules/playwright-ctrf-json-reporter": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/playwright-ctrf-json-reporter/-/playwright-ctrf-json-reporter-0.0.9.tgz",
-      "integrity": "sha512-Qw5KEPfZWj+naIzk3ZStITdEtDTzBnQoVJ8WucHlmSKXC4gMhgk6GYHsD4b39trOO34PKDSQwJLYYhmsJi/PUA==",
-      "dev": true
-    },
-    "node_modules/playwright/node_modules/playwright-core": {
-      "version": "1.41.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.2.tgz",
-      "integrity": "sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==",
+    "node_modules/playwright-core": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
+      "integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/playwright-ctrf-json-reporter": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/playwright-ctrf-json-reporter/-/playwright-ctrf-json-reporter-0.0.9.tgz",
+      "integrity": "sha512-Qw5KEPfZWj+naIzk3ZStITdEtDTzBnQoVJ8WucHlmSKXC4gMhgk6GYHsD4b39trOO34PKDSQwJLYYhmsJi/PUA==",
+      "dev": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -2036,12 +2039,12 @@
       }
     },
     "@playwright/test": {
-      "version": "1.41.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.2.tgz",
-      "integrity": "sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.0.tgz",
+      "integrity": "sha512-rNX5lbNidamSUorBhB4XZ9SQTjAqfe5M+p37Z8ic0jPFBMo5iCtQz1kRWkEMg+rYOKSlVycpQmpqjSFq7LXOfg==",
       "dev": true,
       "requires": {
-        "playwright": "1.41.2"
+        "playwright": "1.44.0"
       }
     },
     "@types/node": {
@@ -2063,7 +2066,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "agent-base": {
       "version": "6.0.2",
@@ -2401,7 +2405,8 @@
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
       "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "7.2.0",
@@ -3026,22 +3031,20 @@
       "dev": true
     },
     "playwright": {
-      "version": "1.41.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.2.tgz",
-      "integrity": "sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
+      "integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.41.2"
-      },
-      "dependencies": {
-        "playwright-core": {
-          "version": "1.41.2",
-          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.2.tgz",
-          "integrity": "sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==",
-          "dev": true
-        }
+        "playwright-core": "1.44.0"
       }
+    },
+    "playwright-core": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
+      "integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
+      "dev": true
     },
     "playwright-ctrf-json-reporter": {
       "version": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "^1.41.2",
+    "@playwright/test": "^1.44.0",
     "@types/node": "^20.11.17",
     "browserstack-local": "^1.4.8",
     "dotenv": "^16.0.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,18 +21,31 @@ const summaryName = () => `${process.env.CATEGORY}-summary.json`;
 /**
  * See https://playwright.dev/docs/test-configuration.
  * Read more about Playwright timeouts in: https://testerops.com/playwright-timeouts/
- * 
+ *
  * Timeouts were set by `ms`
  */
 export default defineConfig({
+  // To use
+  // trace: 'on-first-retry'
+  // below to set retries: (to at least) 1
+  retries: 1,
+
+  // uncomment to run tests in parallel
+  // fullyParallel: true,
+  // AND uncomment line below
+  // OR reverse to run tests sequentially
   workers: 1,
+
   // Set timeout for each test (currently 2 minutes)
-  timeout: 2 * 60 * 1000, 
-  // Set maximum time the whole test suite can run (currently 30 minutes)
-  globalTimeout: 30 * 60 * 1000,
+  timeout: 2 * 60 * 1000,
+
+  // Set maximum time the whole test suite can run (currently 40 minutes)
+  globalTimeout: 40 * 60 * 1000,
+
   expect: {
     // Maximum time expect() should wait for the condition to be met
     // For example in `await expect(locator).toHaveText();`
+    // (currently 2 minutes)
     timeout: 2 * 60 * 1000,
   },
   testDir: './tests',
@@ -45,7 +58,7 @@ export default defineConfig({
       },
     ],
     [
-      'json', 
+      'json',
       {
         outputFile: `playwright-summary/${summaryName()}`,
         open: 'never',
@@ -58,6 +71,8 @@ export default defineConfig({
     baseURL: config.baseURL,
     // Implied and comes into picture during the navigation from one page to another
     navigationTimeout: 1 * 60 * 1000,
+    // If the test fails, it will retry once and create trace file if that fails
+    trace: 'on-first-retry',
   },
 
   /* Configure projects for major browsers */

--- a/tests/details/details-page.spec.ts
+++ b/tests/details/details-page.spec.ts
@@ -72,13 +72,9 @@ test(`Load theater: radio as priv'd user`, async ({
     await loginPage.loginAs('privs');
   });
   await test.step(`Go to radio details page and verify priv'd user borrow program`, async () => {
-    console.log('gotoPage');
     await detailsPage.gotoPage('WGBH_89_7_FM_20210918_040000');
-    console.log('radioPlayerTheaterDisplay');
     await detailsPage.radioPlayerTheaterDisplay();
-    console.log('verifyRadioBorrowProgramAvailable');
     await detailsPage.verifyRadioBorrowProgramAvailable();
-    console.log('verifyRadioBorrowProgramAvailable done');
   });
 });
 

--- a/tests/details/details-page.spec.ts
+++ b/tests/details/details-page.spec.ts
@@ -72,9 +72,13 @@ test(`Load theater: radio as priv'd user`, async ({
     await loginPage.loginAs('privs');
   });
   await test.step(`Go to radio details page and verify priv'd user borrow program`, async () => {
+    console.log('gotoPage');
     await detailsPage.gotoPage('WGBH_89_7_FM_20210918_040000');
+    console.log('radioPlayerTheaterDisplay');
     await detailsPage.radioPlayerTheaterDisplay();
+    console.log('verifyRadioBorrowProgramAvailable');
     await detailsPage.verifyRadioBorrowProgramAvailable();
+    console.log('verifyRadioBorrowProgramAvailable done');
   });
 });
 

--- a/tests/page-objects/details-page.ts
+++ b/tests/page-objects/details-page.ts
@@ -133,8 +133,12 @@ export class DetailsPage {
   }
 
   async verifyRadioBorrowProgramAvailable() {
+    // NOTE: using more than one class in locator seems to be broken
+    // changed: this.page.locator('div.topinblock.borrow-program-btn'),
+    // to:      this.page.locator('div.borrow-program-btn'),
+    // This appears to be more reliable.
     await expect(
-      this.page.locator('div.topinblock.borrow-program-btn'),
+      this.page.locator('div.borrow-program-btn'),
     ).toBeVisible();
     await expect(this.page.locator('#radio-borrow-button')).toBeVisible();
 
@@ -145,7 +149,7 @@ export class DetailsPage {
 
   async verifyRadioBorrowProgramUnavailable() {
     await expect(
-      this.page.locator('div.topinblock.borrow-program-btn'),
+      this.page.locator('div.borrow-program-btn'),
     ).not.toBeVisible();
     await expect(this.page.locator('#radio-borrow-button')).not.toBeVisible();
 

--- a/tests/page-objects/login-page.ts
+++ b/tests/page-objects/login-page.ts
@@ -27,17 +27,32 @@ export class LoginPage {
       asUser.password,
     );
     await this.page.locator('input.btn.btn-primary.btn-submit').click();
-    await this.page.waitForTimeout(10000);
+    /* NOTE: We almost never want to use waitForTimeout() in tests
+     *       This adds an EXTRA delay that can make tests flaky
+     */
+    // await this.page.waitForTimeout(10000);
 
+    /* NOTE: This URL check seems to fail
+     * Waiting for the response seems a temporary fix
+     * We should:
+     * 1. wait for the page to load
+     * 2. Have a check for user facing elements like user menu
+     */
     // should go back to baseUrl
-    await this.page.waitForURL('/');
+    // await this.page.waitForURL('/');
+
+    await this.page.waitForResponse(response => response.status() === 200);
   }
 
   async assertAccountSettingsDisplayed() {
-    await this.page.waitForTimeout(3000);
+    /* NOTE: We almost never want to use waitForTimeout() in tests
+     */
+    //await this.page.waitForTimeout(3000);
 
     await this.page.goto('/account/index.php?settings=1');
-    await this.page.waitForLoadState('networkidle', { timeout: 60000 });
+    /* NOTE: We almost never want to use waitForLoadState('networkidle'...
+     */
+    // await this.page.waitForLoadState('networkidle', { timeout: 60000 });
 
     await expect(this.authTemplate).toBeVisible();
 
@@ -64,7 +79,9 @@ export class LoginPage {
 
   async notLoggedIn() {
     await this.page.goto('/account/index.php?settings=1');
-    await this.page.waitForLoadState('networkidle', { timeout: 60000 });
+    /* NOTE: We almost never want to use waitForLoadState('networkidle'...
+     */
+    // await this.page.waitForLoadState('networkidle', { timeout: 60000 });
 
     await expect(this.authTemplate).not.toBeVisible();
     expect(


### PR DESCRIPTION
A number of changes from best practices and testing to get login and details page objects to not be flaky,

`npm run test:details` should always run without failed tests and `npm run test` should have no details-based flaky tests.  

webdev-6852