### PR TITLE
Update locators in about pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@playwright/test": "^1.49.0",
         "@types/node": "^20.11.17",
-        "browserstack-node-sdk": "^1.34.23",
+        "browserstack-node-sdk": "^1.34.33",
         "dotenv": "^16.0.3",
         "eslint": "^8.44.0",
         "eslint-config-prettier": "^8.8.0",
@@ -1204,9 +1204,9 @@
       }
     },
     "node_modules/browserstack-node-sdk": {
-      "version": "1.34.23",
-      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.34.23.tgz",
-      "integrity": "sha512-C/pQGaHcVBR8M9I2rpH2pig9g8hc4lDMxyzY3j8LuuUPT9GsI5YzlY7kC26eC8IO9g0qnYlhxG51K08aqDCr5w==",
+      "version": "1.34.33",
+      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.34.33.tgz",
+      "integrity": "sha512-OtWYpnoshVk13KRzo3K9UDI0IB1nhu+Ff0anebJ2mWel8pc8Tq4cTkRNhFSTsE+Ff1RL88WMAsKl8e0Xe0UJ2g==",
       "dev": true,
       "dependencies": {
         "@google-cloud/compute": "^4.0.1",
@@ -7377,9 +7377,9 @@
       }
     },
     "browserstack-node-sdk": {
-      "version": "1.34.23",
-      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.34.23.tgz",
-      "integrity": "sha512-C/pQGaHcVBR8M9I2rpH2pig9g8hc4lDMxyzY3j8LuuUPT9GsI5YzlY7kC26eC8IO9g0qnYlhxG51K08aqDCr5w==",
+      "version": "1.34.33",
+      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.34.33.tgz",
+      "integrity": "sha512-OtWYpnoshVk13KRzo3K9UDI0IB1nhu+Ff0anebJ2mWel8pc8Tq4cTkRNhFSTsE+Ff1RL88WMAsKl8e0Xe0UJ2g==",
       "dev": true,
       "requires": {
         "@google-cloud/compute": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@playwright/test": "^1.49.0",
     "@types/node": "^20.11.17",
-    "browserstack-node-sdk": "^1.34.23",
+    "browserstack-node-sdk": "^1.34.33",
     "dotenv": "^16.0.3",
     "eslint": "^8.44.0",
     "eslint-config-prettier": "^8.8.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ const reportName = () => `${process.env.CATEGORY}/${formattedDateTime()}`;
 export default defineConfig({
   workers: 5,
   // Timeout for each test
-  timeout: 2 * 60 * 1000,         // 2 mins
+  timeout: 3 * 60 * 1000,         // 3 mins
   // Maximum time the whole test suite can run
   globalTimeout: 20 * 60 * 1000,  // 20 mins
   testDir: './tests',

--- a/tests/about/about.spec.ts
+++ b/tests/about/about.spec.ts
@@ -34,6 +34,7 @@ test('About > Terms of Service page has correct title and text', async ({page}) 
 
 test('About > News Stories page has correct title and text', async ({page}) => {
   await page.goto(identifier.about.news);
+  await page.waitForURL('**/news-stories');
   await expect(page).toHaveTitle(/News Stories/);
   await expect(page.locator('h1:has-text("News stories")')).toBeVisible();
   await expect(page.locator('#main-content')).toContainText(

--- a/tests/about/about.spec.ts
+++ b/tests/about/about.spec.ts
@@ -8,7 +8,7 @@ test.beforeEach(async ({ context }) => {
 
 test('Canonical About page has correct title and text', async ({ page }) => {
   await page.goto(identifier.about.url);
-  await expect(page).toHaveTitle(/Internet Archive: Digital Library/);
+  await expect(page).toHaveTitle(/About IA/);
   await expect(page.locator('h1:has-text("About the Internet Archive")')).toBeVisible();
   await expect(page.locator('#maincontent').locator('a:has-text("Job Opportunities")')).toBeVisible();
   await expect(page.locator('#maincontent').locator('a:has-text("Terms of Service")')).toBeVisible();
@@ -18,14 +18,14 @@ test('Canonical About page has correct title and text', async ({ page }) => {
 
 test('About > Jobs page has correct title and text', async ({ page }) => {
   await page.goto(identifier.about.jobs);
-  await expect(page).toHaveTitle(/Internet Archive: Digital Library/);
+  await expect(page).toHaveTitle(/Jobs/);
   await expect(page.locator('h1:has-text("Job Opportunities")')).toBeVisible();
   await expect(page.locator('#maincontent')).toContainText('Based in San Francisco');
 });
 
 test('About > Terms of Service page has correct title and text', async ({page}) => {
   await page.goto(identifier.about.terms);
-  await expect(page).toHaveTitle(/Internet Archive: Digital Library/);
+  await expect(page).toHaveTitle(/Terms of Use/);
   await expect(page.locator('h1:has-text("Terms of Use")')).toBeVisible();
   await expect(page.locator('#maincontent')).toContainText(
     'This terms of use agreement',
@@ -34,7 +34,7 @@ test('About > Terms of Service page has correct title and text', async ({page}) 
 
 test('About > News Stories page has correct title and text', async ({page}) => {
   await page.goto(identifier.about.news);
-  await page.waitForURL('**/news-stories');
+  await page.waitForURL(/news-stories/);
   await expect(page).toHaveTitle(/News Stories/);
   await expect(page.locator('h1:has-text("News stories")')).toBeVisible();
   await expect(page.locator('#main-content')).toContainText(

--- a/tests/about/about.spec.ts
+++ b/tests/about/about.spec.ts
@@ -8,23 +8,24 @@ test.beforeEach(async ({ context }) => {
 
 test('Canonical About page has correct title and text', async ({ page }) => {
   await page.goto(identifier.about.url);
-  await expect(page).toHaveTitle(/About IA/);
+  await expect(page).toHaveTitle(/Internet Archive: Digital Library/);
   await expect(page.locator('h1:has-text("About the Internet Archive")')).toBeVisible();
-  await expect(page.locator('a:has-text("Terms of Service")')).toBeVisible();
-  await expect(page.locator('a:has-text("Job Opportunities")')).toBeVisible();
+  await expect(page.locator('#maincontent').locator('a:has-text("Job Opportunities")')).toBeVisible();
+  await expect(page.locator('#maincontent').locator('a:has-text("Terms of Service")')).toBeVisible();
   await expect(page.locator('#maincontent')).toContainText('501(c)(3) non-profit');
+  await expect(page.locator('news-stories')).toBeVisible();
 });
 
 test('About > Jobs page has correct title and text', async ({ page }) => {
   await page.goto(identifier.about.jobs);
-  await expect(page).toHaveTitle(/Jobs/);
+  await expect(page).toHaveTitle(/Internet Archive: Digital Library/);
   await expect(page.locator('h1:has-text("Job Opportunities")')).toBeVisible();
   await expect(page.locator('#maincontent')).toContainText('Based in San Francisco');
 });
 
 test('About > Terms of Service page has correct title and text', async ({page}) => {
   await page.goto(identifier.about.terms);
-  await expect(page).toHaveTitle(/Terms of Use/);
+  await expect(page).toHaveTitle(/Internet Archive: Digital Library/);
   await expect(page.locator('h1:has-text("Terms of Use")')).toBeVisible();
   await expect(page.locator('#maincontent')).toContainText(
     'This terms of use agreement',


### PR DESCRIPTION
## Changes:

- update title page text assertion
- update locators for about page, jobs page, ToS page
- update browserstack-node-sdk version
- increased global page timeout from 2mins to 3mins
   - this is something that we can improve on the backend side as the page loads/rendering sometimes takes awhile

Note:
- I cancelled the test checks for other tests for now to save pipeline build time