### PR TITLE
update login page object flow and text selector checking

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ const reportName = () => `${process.env.CATEGORY}/${formattedDateTime()}`;
 export default defineConfig({
   workers: 5,
   // Timeout for each test
-  timeout: 3 * 60 * 1000,         // 3 mins
+  timeout: 5 * 60 * 1000,         // 5 mins
   // Maximum time the whole test suite can run
   globalTimeout: 20 * 60 * 1000,  // 20 mins
   testDir: './tests',

--- a/tests/page-objects/login-page.ts
+++ b/tests/page-objects/login-page.ts
@@ -34,10 +34,8 @@ export class LoginPage {
   }
 
   async assertAccountSettingsDisplayed() {
-    await this.page.waitForTimeout(3000);
-
     await this.page.goto(accountSettings.url);
-    await this.page.waitForLoadState('networkidle', { timeout: 60000 });
+    await this.page.waitForURL(/settings=1/);
 
     await expect(this.authTemplate).toBeVisible();
 
@@ -50,7 +48,7 @@ export class LoginPage {
     ).toBe('Account settings');
 
     expect(await this.authTemplate.locator('form > p').innerText()).toBe(
-      'Please verify your password to access account settings.',
+      'To access your account settings, as an extra security measure, please enter your password.',
     );
 
     expect(
@@ -64,7 +62,7 @@ export class LoginPage {
 
   async notLoggedIn() {
     await this.page.goto(accountSettings.url);
-    await this.page.waitForLoadState('networkidle', { timeout: 60000 });
+    await this.page.waitForURL(/settings=1/);
 
     await expect(this.authTemplate).not.toBeVisible();
     expect(


### PR DESCRIPTION
## Changes:
- update login locator expect assertion texts
- increased global page timeout from 3 mins to 5mins
this is something that we can improve on the backend side as the page loads/rendering sometimes takes awhile

Note:
- I cancelled the test checks again for other tests for now to save pipeline build time